### PR TITLE
Review ind sector

### DIFF
--- a/2024-06-04/ind/helper_ind_elec.csv
+++ b/2024-06-04/ind/helper_ind_elec.csv
@@ -1,5 +1,5 @@
 "id","region","year","type","conversion_factor_sec_elec_ind","conversion_factor_iip_elec","bandwidth_type","version","method","source","comment"
-1,"DE",2021,"helper_ind_elec",1.0,1.0,"{}","v1","{}","{}","{}"
+1,"DE",2021,"helper_ind_elec",1.0,1.0,"{}",srd_range_draft,"{}","{}","{}"
 2,"DE",2024,"helper_ind_elec",1.0,1.0,"{}","v1","{}","{}","{}"
 3,"DE",2027,"helper_ind_elec",1.0,1.0,"{}","v1","{}","{}","{}"
 4,"DE",2030,"helper_ind_elec",1.0,1.0,"{}","v1","{}","{}","{}"


### PR DESCRIPTION
Please check the individual commits and commit messages for what is wrong.

## **General Feedback**
1. The correct version in this state should be: **srd_range_draft**
1. Please fix the missing global tables references --> add columns from "missing_col_in_reference_table" to table `global_emission_factors `

## **Questions**

1. e.g in [`ind_automobile_boiler_space_heat_gas_0`](https://openenergyplatform.org/dataedit/view/model_draft/ind_automobile_boiler_space_heat_gas_0) your source dict is referencing column `'ef': '7UBA2023a'`. Column `ef` does not exist in the table. Do you mean all columns that start with `ef` by that?


## **Generel impressions**

You applied the majority of conventions already 😍 Good job!
Please, check for consistency across all your tables additionally to my remarks.